### PR TITLE
add python as runtime dependency

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,7 +12,7 @@ source:
   sha256: {{ sha256 }}
 
 build:
-  number: 0
+  number: 1
   skip: True  # [py3k or win]
   script: python setup.py install --single-version-externally-managed --record record.txt
 
@@ -24,6 +24,7 @@ requirements:
     - cython
 
   run:
+    - python
     - scipy
     - numpy x.x
     - matplotlib


### PR DESCRIPTION
This should force conda packages to only be installable on python2.7